### PR TITLE
fix: update AI model identifier in SDK and documentation

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -605,7 +605,7 @@ Moorcheh Python SDK. Use this file as guidance for LLMs and tooling when reading
 				client.answer.generate(namespace="my-document-collection", query="What are the main benefits of Moorcheh?", top_k=5)
 	- Example request (SDK, Direct AI Mode):
 		with MoorchehClient() as client:
-				client.answer.generate(namespace="", query="Explain quantum computing in simple terms", ai_model="anthropic.claude-sonnet-4-20250514-v1:0", temperature=0.7)
+				client.answer.generate(namespace="", query="Explain quantum computing in simple terms", ai_model="anthropic.claude-sonnet-4-6", temperature=0.7)
 
 ## Python SDK (key methods and behavior)
 

--- a/moorcheh_sdk/_legacy_client.py
+++ b/moorcheh_sdk/_legacy_client.py
@@ -274,7 +274,7 @@ class LegacyClientMixin:
         namespace: str,
         query: str,
         top_k: int = 5,
-        ai_model: str = "anthropic.claude-sonnet-4-20250514-v1:0",
+        ai_model: str = "anthropic.claude-sonnet-4-6",
         chat_history: list[ChatHistoryItem] | None = None,
         temperature: float = 0.7,
         header_prompt: str | None = None,
@@ -290,7 +290,7 @@ class LegacyClientMixin:
             query: The question or prompt to answer.
             top_k: The number of search results to use as context. Defaults to 5.
             ai_model: The identifier of the LLM to use.
-                Defaults to "anthropic.claude-sonnet-4-20250514-v1:0".
+                Defaults to "anthropic.claude-sonnet-4-6".
             chat_history: Optional list of previous conversation turns for context.
                 Each item should be a dictionary. Defaults to None.
             temperature: The sampling temperature for the LLM (0.0 to 1.0).

--- a/moorcheh_sdk/resources/answer.py
+++ b/moorcheh_sdk/resources/answer.py
@@ -16,7 +16,7 @@ class Answer(BaseResource):
         query: str,
         namespace: str | None = None,
         top_k: int | None = None,
-        ai_model: str = "anthropic.claude-sonnet-4-20250514-v1:0",
+        ai_model: str = "anthropic.claude-sonnet-4-6",
         chat_history: list[ChatHistoryItem] | None = None,
         temperature: float = 0.7,
         header_prompt: str | None = None,
@@ -36,7 +36,7 @@ class Answer(BaseResource):
             namespace: The name of the text-based namespace to search within.
             top_k: The number of search results to use as context. Defaults to 5.
             ai_model: The identifier of the LLM to use.
-                Defaults to "anthropic.claude-sonnet-4-20250514-v1:0".
+                Defaults to "anthropic.claude-sonnet-4-6".
             chat_history: Optional list of previous conversation turns for context.
                 Each item should be a dictionary. Defaults to None.
             temperature: The sampling temperature for the LLM (0.0 to 1.0).
@@ -158,7 +158,7 @@ class AsyncAnswer(AsyncBaseResource):
         query: str,
         namespace: str | None = None,
         top_k: int | None = None,
-        ai_model: str = "anthropic.claude-sonnet-4-20250514-v1:0",
+        ai_model: str = "anthropic.claude-sonnet-4-6",
         chat_history: list[ChatHistoryItem] | None = None,
         temperature: float = 0.7,
         header_prompt: str | None = None,
@@ -178,7 +178,7 @@ class AsyncAnswer(AsyncBaseResource):
             namespace: The name of the text-based namespace to search within.
             top_k: The number of search results to use as context. Defaults to 5.
             ai_model: The identifier of the LLM to use.
-                Defaults to "anthropic.claude-sonnet-4-20250514-v1:0".
+                Defaults to "anthropic.claude-sonnet-4-6".
             chat_history: Optional list of previous conversation turns for context.
                 Each item should be a dictionary. Defaults to None.
             temperature: The sampling temperature for the LLM (0.0 to 1.0).

--- a/tests/resources/test_answer.py
+++ b/tests/resources/test_answer.py
@@ -139,7 +139,7 @@ def test_empty_namespace(client, mocker, mock_response):
     expected_payload = {
         "namespace": "",
         "query": query,
-        "aiModel": "anthropic.claude-sonnet-4-20250514-v1:0",
+        "aiModel": "anthropic.claude-sonnet-4-6",
         "chatHistory": [],
         "temperature": 0.7,
         "headerPrompt": "",
@@ -165,7 +165,7 @@ def test_structured_response(client, mocker, mock_response):
     expected_payload = {
         "namespace": "my_ns",
         "query": query,
-        "aiModel": "anthropic.claude-sonnet-4-20250514-v1:0",
+        "aiModel": "anthropic.claude-sonnet-4-6",
         "chatHistory": [],
         "temperature": 0.7,
         "headerPrompt": "",
@@ -195,7 +195,7 @@ def test_structured_response_with_empty_namespace(client, mocker, mock_response)
     expected_payload = {
         "namespace": "",
         "query": query,
-        "aiModel": "anthropic.claude-sonnet-4-20250514-v1:0",
+        "aiModel": "anthropic.claude-sonnet-4-6",
         "chatHistory": [],
         "temperature": 0.7,
         "headerPrompt": "",

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -148,7 +148,7 @@ async def test_answer_generate(client):
             "query": "hello",
             "top_k": 5,
             "type": "text",
-            "aiModel": "anthropic.claude-sonnet-4-20250514-v1:0",
+            "aiModel": "anthropic.claude-sonnet-4-6",
             "chatHistory": [],
             "temperature": 0.7,
             "headerPrompt": "",


### PR DESCRIPTION
Changed the default AI model identifier from "anthropic.claude-sonnet-4-20250514-v1:0" to "anthropic.claude-sonnet-4-6" across multiple files, including the SDK and test cases, to ensure consistency and accuracy in model usage.